### PR TITLE
Implementing Room 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -50,8 +51,8 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'com.google.android.material:material:1.5.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
@@ -63,6 +64,14 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 
-    implementation "androidx.navigation:navigation-compose:2.4.0-rc01"
+    implementation "androidx.navigation:navigation-compose:2.5.0-alpha01"
+
+    //Room Components
+    implementation "androidx.room:room-runtime:2.4.1"
+    kapt "androidx.room:room-compiler:2.4.1"
+    implementation "androidx.room:room-ktx:2.4.1"
+    androidTestImplementation "androidx.room:room-testing:2.4.1"
+    api 'android.arch.persistence.room:runtime:1.1.1'
+
 
 }

--- a/app/src/main/java/com/example/keniphhomemaintenance/CompanionObjects.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/CompanionObjects.kt
@@ -1,0 +1,15 @@
+package com.example.keniphhomemaintenance
+
+import com.example.keniphhomemaintenance.dwellings.Dwelling
+
+class CompanionObjects {
+
+    companion object {
+        const val PLACEHOLDER_ID = 0
+        fun getDefaultDwellings(): List<Dwelling> = listOf(
+            Dwelling(1, "My home", "1337 Street Lane, Rantoul, IL 61866"),
+            Dwelling(2, "Tenant complex", "789 Mayju Look., Rantoul, IL 61866")
+        )
+    }
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/MainActivity.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/MainActivity.kt
@@ -13,12 +13,11 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             KeniphHomeMaintenanceTheme {
-                Surface(color = MaterialTheme.colors.background) {
-                }
+                Surface(color = MaterialTheme.colors.background) { }
                 Navigation()
-            }
             }
         }
     }
+}
 
 

--- a/app/src/main/java/com/example/keniphhomemaintenance/MainActivity.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
-import com.example.keniphhomemaintenance.ui.navigation.Navigation
+import com.example.keniphhomemaintenance.navigation.Navigation
 import com.example.keniphhomemaintenance.ui.theme.KeniphHomeMaintenanceTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/keniphhomemaintenance/database/DwellingWithMaintenanceItems.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/database/DwellingWithMaintenanceItems.kt
@@ -1,0 +1,15 @@
+package com.example.keniphhomemaintenance.database
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.example.keniphhomemaintenance.dwellings.Dwelling
+import com.example.keniphhomemaintenance.maintenance_screen.MaintenanceItem
+
+data class DwellingWithMaintenanceItems (
+    @Embedded val dwelling: Dwelling,
+    @Relation(
+        parentColumn = "dwellingID",
+        entityColumn = "dwellingID"
+    )
+    val maintenanceItems: List<MaintenanceItem>
+)

--- a/app/src/main/java/com/example/keniphhomemaintenance/database/DwellingsDao.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/database/DwellingsDao.kt
@@ -1,0 +1,34 @@
+package com.example.keniphhomemaintenance.database
+
+import androidx.room.*
+import com.example.keniphhomemaintenance.dwellings.Dwelling
+import com.example.keniphhomemaintenance.maintenance_screen.MaintenanceItem
+
+@Dao
+interface DwellingsDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addDwellingToDb(dwelling: Dwelling): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun prePopulateDwellings(dwellings: List<Dwelling>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addMaintenanceItemToDb(maintenanceItem: MaintenanceItem)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun prePopulateMaintenanceItems(maintenanceItems: List<MaintenanceItem>)
+
+    @Transaction
+    @Query("SELECT * FROM dwellings_table WHERE dwellingID = :dwellingID")
+    suspend fun getMaintenanceItemsForDwellingFromDb(dwellingID: Int): List<DwellingWithMaintenanceItems>
+
+    @Transaction
+    @Query("SELECT * FROM dwellings_table")
+    suspend fun getDwellingsListFromDb(): List<Dwelling>
+
+    @Transaction
+    @Query("SELECT COUNT(*) FROM maintenance_item_table WHERE maintenanceItemID = :maintenanceItemID")
+    fun checkIfDwellingsHavePrePopulatedData(maintenanceItemID: Int): Int
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/database/KeniphDatabase.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/database/KeniphDatabase.kt
@@ -1,0 +1,81 @@
+package com.example.keniphhomemaintenance.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.example.keniphhomemaintenance.CompanionObjects.Companion.getDefaultDwellings
+import com.example.keniphhomemaintenance.dwellings.Dwelling
+import com.example.keniphhomemaintenance.dwellings.DwellingsViewModel.Companion.getDefaultMaintenanceItems
+import com.example.keniphhomemaintenance.maintenance_screen.MaintenanceItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Database(entities =
+[
+    MaintenanceItem::class,
+    Dwelling::class
+], version = 1, exportSchema = true)
+abstract class KeniphDatabase: RoomDatabase() {
+
+    abstract fun dwellingsDao(): DwellingsDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: KeniphDatabase? = null
+
+        fun getKeniphDatabase(context: Context): KeniphDatabase {
+            val tempInstance = INSTANCE
+
+            tempInstance?.let {
+                return tempInstance
+            } ?: run {
+
+                synchronized(this) {
+                    val instance = Room.databaseBuilder(
+                        context.applicationContext,
+                        KeniphDatabase::class.java,
+                        "keniph_database"
+                    ).addCallback(prePopulateDatabaseCallback())
+                        .build()
+
+                    INSTANCE = instance
+                    return instance
+                }
+
+            }
+        }
+
+        private fun prePopulateDatabaseCallback(): Callback {
+            return object : Callback() {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    super.onCreate(db)
+                    INSTANCE?.dwellingsDao()
+                        ?.let { dwellingsDao ->
+                            prePopulateDwellings(dwellingsDao)
+                            prePopulateMaintenanceItems(dwellingsDao)
+                        }
+                }
+            }
+        }
+
+        private fun prePopulateDwellings(dwellingsDao: DwellingsDao) {
+            CoroutineScope(Dispatchers.IO).launch {
+                dwellingsDao.prePopulateDwellings(
+                    getDefaultDwellings()
+                )
+            }
+        }
+
+        private fun prePopulateMaintenanceItems(dwellingsDao: DwellingsDao) {
+            val maintenanceItems = getDefaultMaintenanceItems(1) + getDefaultMaintenanceItems(2)
+            CoroutineScope(Dispatchers.IO).launch {
+                dwellingsDao.prePopulateMaintenanceItems(maintenanceItems)
+            }
+        }
+
+    }
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/database/KeniphRepository.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/database/KeniphRepository.kt
@@ -1,0 +1,30 @@
+package com.example.keniphhomemaintenance.database
+
+import com.example.keniphhomemaintenance.dwellings.Dwelling
+import com.example.keniphhomemaintenance.maintenance_screen.MaintenanceItem
+
+class KeniphRepository(
+    private val dwellingsDao: DwellingsDao
+) {
+
+    suspend fun addDwellingToDb(dwelling: Dwelling): Long {
+        return dwellingsDao.addDwellingToDb(dwelling)
+    }
+
+    suspend fun addMaintenanceItemToDb(maintenanceItem: MaintenanceItem) {
+        dwellingsDao.addMaintenanceItemToDb(maintenanceItem)
+    }
+
+    suspend fun prePopulateMaintenanceItems(maintenanceItems: List<MaintenanceItem>) {
+        dwellingsDao.prePopulateMaintenanceItems(maintenanceItems)
+    }
+
+    suspend fun getMaintenanceItemsForDwellingFromDb(dwellingID: Int): List<DwellingWithMaintenanceItems> {
+        return dwellingsDao.getMaintenanceItemsForDwellingFromDb(dwellingID)
+    }
+
+    suspend fun getDwellingsListFromDb(): List<Dwelling> {
+        return dwellingsDao.getDwellingsListFromDb()
+    }
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/Dwelling.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/Dwelling.kt
@@ -1,6 +1,12 @@
 package com.example.keniphhomemaintenance.dwellings
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "dwellings_table")
 class Dwelling(
+    @PrimaryKey(autoGenerate = true)
+    val dwellingID: Int,
     val name: String,
     val address: String
 )

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingItem.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingItem.kt
@@ -42,6 +42,7 @@ fun DwellingItem(dwelling: Dwelling, navController: NavController) {
                 Button(onClick = {
                     navController.navigate(
                         Screen.MaintenanceListScreen.withArgs(
+                            dwelling.dwellingID.toString(),
                             dwelling.name,
                             dwelling.address
                         )

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsNavArgParameters.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsNavArgParameters.kt
@@ -2,6 +2,7 @@ package com.example.keniphhomemaintenance.dwellings
 
 class DwellingsNavArgParameters {
     companion object {
+        const val DWELLING_ID = "id"
         const val DWELLING_NAME = "name"
         const val DWELLING_ADDRESS = "address"
     }

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsScreenView.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsScreenView.kt
@@ -1,12 +1,20 @@
 package com.example.keniphhomemaintenance.dwellings
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.FabPosition
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.example.keniphhomemaintenance.Dimens
@@ -15,12 +23,12 @@ import com.example.keniphhomemaintenance.ui.cookbook.KeniphFloatingActionButton
 @Composable
 fun DwellingsScreenView(
     navController: NavController,
-    dwellingsViewModel: DwellingsViewModel = viewModel()
+    dwellingsViewModel: DwellingsViewModel = viewModel(
+        factory = DwellingsViewModelFactory(LocalContext.current)
+    )
 ) {
-
     val isDwellingDialogVisible = remember { mutableStateOf(false) }
-
-    val listOfDwellings = dwellingsViewModel.dwellingsList.value
+    val dwellingsList = dwellingsViewModel.dwellings.value
 
     Scaffold(
         modifier = Modifier
@@ -36,6 +44,14 @@ fun DwellingsScreenView(
             NewDwellingDialog(isDwellingDialogVisible)
         }
     }
+
+    if (!dwellingsViewModel.loadedDwellingsPreviously.value) {
+        LaunchedEffect(true) {
+            dwellingsViewModel.getDwellingsList()
+            dwellingsViewModel.loadedDwellingsPreviously.value = true
+        }
+    }
+
     LazyColumn(
         modifier = Modifier
             .padding(bottom = Dimens.LAZY_COLUMN_BOTTOM_PADDING)
@@ -45,11 +61,13 @@ fun DwellingsScreenView(
             vertical = Dimens.LAZY_COLUMN_VERT_CONTENT_PADDING
         )
     ) {
+        dwellingsViewModel.getDwellingsList()
         items(
-            items = listOfDwellings,
+            items = dwellingsList,
             itemContent = {
                 DwellingItem(dwelling = it, navController)
             }
         )
     }
 }
+

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsViewModel.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsViewModel.kt
@@ -1,29 +1,55 @@
 package com.example.keniphhomemaintenance.dwellings
 
+import android.content.Context
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.keniphhomemaintenance.CompanionObjects.Companion.PLACEHOLDER_ID
+import com.example.keniphhomemaintenance.R
+import com.example.keniphhomemaintenance.database.KeniphDatabase
+import com.example.keniphhomemaintenance.database.KeniphRepository
+import com.example.keniphhomemaintenance.maintenance_screen.MaintenanceItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-class DwellingsViewModel : ViewModel() {
+class DwellingsViewModel(context: Context) : ViewModel() {
 
-    private val placeholderDwelling1: Dwelling =
-        Dwelling(
-            "My home",
-            "420 Blazit Blvd., Rantoul, IL 61866"
-        )
-    private val placeholderDwelling2: Dwelling = Dwelling(
-        "Tenant complex",
-        "80085 Mayju Look., Rantoul, IL 61866"
-    )
-    val dwellingsList: MutableState<List<Dwelling>> = mutableStateOf(
-        listOf(
-            placeholderDwelling1,
-            placeholderDwelling2
-        )
-    )
+    private val repository: KeniphRepository
+    var dwellings: MutableState<List<Dwelling>> = mutableStateOf(listOf())
+    val loadedDwellingsPreviously: MutableState<Boolean> = mutableStateOf(false)
 
-    fun addDwelling(dwelling: Dwelling) {
-        dwellingsList.value += dwelling
+    init {
+        val dwellingsDao = KeniphDatabase.getKeniphDatabase(context).dwellingsDao()
+        repository = KeniphRepository(dwellingsDao)
     }
 
+    fun addDwelling(dwelling: Dwelling) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val dwellingID = repository.addDwellingToDb(dwelling)
+            prePopulateMaintenanceItems(dwellingID.toInt())
+            getDwellingsList()
+        }
+    }
+
+    fun getDwellingsList() {
+        viewModelScope.launch(Dispatchers.IO) {
+            dwellings.value = repository.getDwellingsListFromDb()
+        }
+    }
+
+    private fun prePopulateMaintenanceItems(dwellingID: Int) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val maintenanceItems = getDefaultMaintenanceItems(dwellingID)
+            repository.prePopulateMaintenanceItems(maintenanceItems)
+        }
+    }
+
+    companion object {
+        fun getDefaultMaintenanceItems(dwellingID: Int): List<MaintenanceItem> = listOf(
+            MaintenanceItem(PLACEHOLDER_ID, R.drawable.ic_baseline_build_24_light, "Change Air Filter", "Due date: 7-Sep-22", "Location: Basement", dwellingID),
+            MaintenanceItem(PLACEHOLDER_ID, R.drawable.ic_baseline_build_24_light, "Break Microwave", "Due date: 11-August-22", "Location: Kitchen", dwellingID),
+            MaintenanceItem(PLACEHOLDER_ID, R.drawable.ic_baseline_build_24_light, "Buy a New Microwave", "Due date: 29-Sep-22", "Location: Target", dwellingID)
+        )
+    }
 }

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsViewModelFactory.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/DwellingsViewModelFactory.kt
@@ -1,0 +1,12 @@
+package com.example.keniphhomemaintenance.dwellings
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class DwellingsViewModelFactory(private val context: Context) :
+    ViewModelProvider.NewInstanceFactory() {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T = DwellingsViewModel(context) as T
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/dwellings/NewDwellingDialog.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/dwellings/NewDwellingDialog.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.keniphhomemaintenance.CompanionObjects.Companion.PLACEHOLDER_ID
 import com.example.keniphhomemaintenance.Dimens
 import com.example.keniphhomemaintenance.R
 import com.example.keniphhomemaintenance.ui.cookbook.KeniphKeyboardActions
@@ -31,7 +33,7 @@ fun NewDwellingDialog(
 
     val newName: MutableState<String> = remember { mutableStateOf("") }
     val newAddress: MutableState<String> = remember { mutableStateOf("") }
-    val dwellingsViewModel: DwellingsViewModel = viewModel()
+    val dwellingsViewModel: DwellingsViewModel = viewModel(factory = DwellingsViewModelFactory(LocalContext.current))
 
     Dialog(onDismissRequest = {})
     {
@@ -71,7 +73,7 @@ fun NewDwellingDialog(
                     if (newAddress.value == "") {
                         newAddress.value = "Blank address. Oops!"
                     }
-                    val createdDwelling = Dwelling(
+                    val createdDwelling = Dwelling(PLACEHOLDER_ID,
                         newName.value,
                         newAddress.value
                     )
@@ -83,4 +85,5 @@ fun NewDwellingDialog(
             }
         }
     }
+
 }

--- a/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItem.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItem.kt
@@ -1,8 +1,15 @@
 package com.example.keniphhomemaintenance.maintenance_screen
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "maintenance_item_table")
 data class MaintenanceItem(
+    @PrimaryKey(autoGenerate = true)
+    val maintenanceItemID: Int,
     val icon: Int,
     val title: String,
     val dueDate: String,
-    val location: String
+    val location: String,
+    val dwellingID: Int
 )

--- a/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItemDialog.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItemDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.keniphhomemaintenance.CompanionObjects.Companion.PLACEHOLDER_ID
 import com.example.keniphhomemaintenance.Dimens.MAINTENANCE_ITEM_CARD_TITLE_TEXT_SIZE
 import com.example.keniphhomemaintenance.Dimens.MAINTENANCE_ITEM_DIALOG_CORNER_RADIUS
 import com.example.keniphhomemaintenance.Dimens.MAINTENANCE_ITEM_DIALOG_LOCATION_FIELD_BOTTOM_PADDING
@@ -27,6 +28,7 @@ import com.example.keniphhomemaintenance.R
 @Composable
 fun NewMaintenanceItemDialog(
     isDialogOpen: MutableState<Boolean>,
+    dwellingID: Int,
     maintenanceViewModel: MaintenanceViewModel = viewModel()
 ) {
     val itemTitle = remember { mutableStateOf("") }
@@ -103,7 +105,8 @@ fun NewMaintenanceItemDialog(
 
                     ExtendedFloatingActionButton(
                         onClick = {
-                            maintenanceViewModel.addMaintenanceItem(itemTitle.value, dueDate.value, location.value)
+                            val newMaintenanceItem = MaintenanceItem(PLACEHOLDER_ID, R.drawable.ic_baseline_build_24_light, itemTitle.value, dueDate.value, location.value, dwellingID)
+                            maintenanceViewModel.addMaintenanceItem(newMaintenanceItem)
                             onMaintenanceItemDialogClose(
                                 isDialogOpen = isDialogOpen,
                                 itemTitle = itemTitle,

--- a/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItemsViewModelFactory.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceItemsViewModelFactory.kt
@@ -1,0 +1,12 @@
+package com.example.keniphhomemaintenance.maintenance_screen
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class MaintenanceItemsViewModelFactory(private val context: Context) :
+    ViewModelProvider.NewInstanceFactory() {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T = MaintenanceViewModel(context) as T
+
+}

--- a/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceScreen.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/maintenance_screen/MaintenanceScreen.kt
@@ -3,15 +3,23 @@ package com.example.keniphhomemaintenance.maintenance_screen
 import androidx.compose.material.FabPosition
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.keniphhomemaintenance.ui.cookbook.KeniphFloatingActionButton
 
 @Composable
-fun MaintenanceScreen(name: String, address: String, maintenanceViewModel: MaintenanceViewModel = viewModel()) {
-    val maintenanceList = maintenanceViewModel.maintenanceItemList.value
+fun MaintenanceScreen(dwellingID: Int, name: String, address: String, maintenanceViewModel: MaintenanceViewModel = viewModel(
+    factory = MaintenanceItemsViewModelFactory(LocalContext.current)
+)) {
+    val maintenanceList = maintenanceViewModel.maintenanceItemsList.value
     val isDialogOpen = remember { mutableStateOf(false) }
+
+    LaunchedEffect(true) {
+        maintenanceViewModel.getMaintenanceItems(dwellingID)
+    }
 
     Scaffold(
         floatingActionButton = {
@@ -20,7 +28,7 @@ fun MaintenanceScreen(name: String, address: String, maintenanceViewModel: Maint
         floatingActionButtonPosition = FabPosition.Center
     ) {
         if (isDialogOpen.value) {
-            NewMaintenanceItemDialog(isDialogOpen)
+            NewMaintenanceItemDialog(isDialogOpen, dwellingID)
         }
     }
 

--- a/app/src/main/java/com/example/keniphhomemaintenance/navigation/Navigation.kt
+++ b/app/src/main/java/com/example/keniphhomemaintenance/navigation/Navigation.kt
@@ -1,4 +1,4 @@
-package com.example.keniphhomemaintenance.ui.navigation
+package com.example.keniphhomemaintenance.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -23,16 +23,21 @@ fun Navigation() {
             DwellingsScreenView(navController = navController)
         }
         composable(
-            route = Screen.MaintenanceListScreen.route + "/{name}" + "/{address}",
+            route = Screen.MaintenanceListScreen.route + "/{id}" + "/{name}" + "/{address}",
             arguments = listOf(
+                navArgument(DwellingsNavArgParameters.DWELLING_ID) {
+                    type = NavType.IntType
+                },
                 navArgument(DwellingsNavArgParameters.DWELLING_NAME) {
                     type = NavType.StringType
-                }, navArgument(DwellingsNavArgParameters.DWELLING_ADDRESS) {
+                },
+                navArgument(DwellingsNavArgParameters.DWELLING_ADDRESS) {
                     type = NavType.StringType
                 }
             )
         ) { entry ->
             MaintenanceScreen(
+                dwellingID = entry.arguments?.getInt(DwellingsNavArgParameters.DWELLING_ID)  ?: 0,
                 name = entry.arguments?.getString(DwellingsNavArgParameters.DWELLING_NAME) ?: defaultDwellingName,
                 address = entry.arguments?.getString(DwellingsNavArgParameters.DWELLING_ADDRESS) ?: defaultDwellingAddress
             )


### PR DESCRIPTION
-Setup initial functionality for Room.  
 -Two tables were created: "dwellings_table" & "maintenance_items_table"
   -"maintenancee_items_table" is related to "dwellings_table" (One-to-N relation)
   -Both tables are accessed via DwellingsDao.kt
-When navigating to the MaintenanceScreen.kt, the primary key for each dwelling is now passed
-Logic was added to the viewModels for DwellingsScreenView.kt and MaintenanceScreen.kt to persist user entries and display them next time the screen is loaded.